### PR TITLE
feat: タスク読み取りAPI実装（GET /api/tasks, GET /api/tasks/{id}） (#4)

### DIFF
--- a/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
@@ -1,0 +1,33 @@
+package com.example.taskmanagement.controller;
+
+import com.example.taskmanagement.dto.TaskResponseDto;
+import com.example.taskmanagement.service.TaskService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tasks")
+public class TaskController {
+
+    private final TaskService taskService;
+
+    public TaskController(TaskService taskService) {
+        this.taskService = taskService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TaskResponseDto>> getTasks(
+            @RequestParam(required = false) String status) {
+        List<TaskResponseDto> tasks = (status != null)
+                ? taskService.getTasksByStatus(status)
+                : taskService.getAllTasks();
+        return ResponseEntity.ok(tasks);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<TaskResponseDto> getTaskById(@PathVariable Integer id) {
+        return ResponseEntity.ok(taskService.getTaskById(id));
+    }
+}

--- a/backend/src/main/java/com/example/taskmanagement/dto/TaskResponseDto.java
+++ b/backend/src/main/java/com/example/taskmanagement/dto/TaskResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.taskmanagement.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record TaskResponseDto(
+        Integer id,
+        String title,
+        String description,
+        String status,
+        String priority,
+        LocalDate dueDate,
+        Integer orderIndex,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}

--- a/backend/src/main/java/com/example/taskmanagement/exception/TaskNotFoundException.java
+++ b/backend/src/main/java/com/example/taskmanagement/exception/TaskNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.taskmanagement.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class TaskNotFoundException extends RuntimeException {
+    public TaskNotFoundException(Integer id) {
+        super("Task not found: id=" + id);
+    }
+}

--- a/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
@@ -1,0 +1,11 @@
+package com.example.taskmanagement.service;
+
+import com.example.taskmanagement.dto.TaskResponseDto;
+
+import java.util.List;
+
+public interface TaskService {
+    List<TaskResponseDto> getAllTasks();
+    List<TaskResponseDto> getTasksByStatus(String status);
+    TaskResponseDto getTaskById(Integer id);
+}

--- a/backend/src/main/java/com/example/taskmanagement/service/TaskServiceImpl.java
+++ b/backend/src/main/java/com/example/taskmanagement/service/TaskServiceImpl.java
@@ -1,0 +1,58 @@
+package com.example.taskmanagement.service;
+
+import com.example.taskmanagement.dto.TaskResponseDto;
+import com.example.taskmanagement.entity.Task;
+import com.example.taskmanagement.exception.TaskNotFoundException;
+import com.example.taskmanagement.repository.TaskRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class TaskServiceImpl implements TaskService {
+
+    private final TaskRepository taskRepository;
+
+    public TaskServiceImpl(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+
+    @Override
+    public List<TaskResponseDto> getAllTasks() {
+        return taskRepository.findAllByOrderByOrderIndexAsc()
+                .stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    @Override
+    public List<TaskResponseDto> getTasksByStatus(String status) {
+        return taskRepository.findByStatus(status)
+                .stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    @Override
+    public TaskResponseDto getTaskById(Integer id) {
+        Task task = taskRepository.findById(id)
+                .orElseThrow(() -> new TaskNotFoundException(id));
+        return toDto(task);
+    }
+
+    private TaskResponseDto toDto(Task task) {
+        return new TaskResponseDto(
+                task.getId(),
+                task.getTitle(),
+                task.getDescription(),
+                task.getStatus(),
+                task.getPriority(),
+                task.getDueDate(),
+                task.getOrderIndex(),
+                task.getCreatedAt(),
+                task.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,10 +12,15 @@ spring:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
+    defer-datasource-initialization: true
     show-sql: true
     properties:
       hibernate:
         format_sql: true
+
+  sql:
+    init:
+      mode: always
 
 server:
   port: 8080

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,0 +1,9 @@
+INSERT INTO tasks (title, description, status, priority, due_date, order_index, created_at, updated_at)
+SELECT * FROM (VALUES
+  ('買い物リスト作成', 'スーパーで買うものをまとめる', 'todo', 'low', DATE '2026-05-01', 1, NOW(), NOW()),
+  ('週次レポート提出', '先週の進捗をまとめて提出する', 'in_progress', 'high', DATE '2026-04-30', 2, NOW(), NOW()),
+  ('コードレビュー', 'PRのコードをレビューする', 'todo', 'medium', DATE '2026-05-02', 3, NOW(), NOW()),
+  ('デプロイ作業', '本番環境へのデプロイを実施', 'done', 'high', DATE '2026-04-28', 4, NOW(), NOW()),
+  ('ミーティング準備', '週次ミーティングのアジェンダ作成', 'todo', 'medium', DATE '2026-05-03', 5, NOW(), NOW())
+) AS v(title, description, status, priority, due_date, order_index, created_at, updated_at)
+WHERE NOT EXISTS (SELECT 1 FROM tasks);


### PR DESCRIPTION
## Summary
- タスク一覧・単体取得 REST API を実装
- PostgreSQL へのテストデータ自動投入（アプリ起動時に5件挿入）
- Service 層・DTO・例外クラスを新規追加

## 変更ファイル
- `application.yml` — SQL 初期化設定追加（`defer-datasource-initialization`, `sql.init.mode`）
- `data.sql` — テストデータ5件（テーブルが空の場合のみ挿入）
- `TaskResponseDto` — API レスポンス用 record DTO
- `TaskNotFoundException` — 404 用カスタム例外
- `TaskService` — サービス層インターフェース
- `TaskServiceImpl` — サービス層実装（既存 Repository メソッドを活用）
- `TaskController` — REST コントローラー（GET /api/tasks, GET /api/tasks/{id}）

## エンドポイント
| Method | URL | 説明 |
|--------|-----|------|
| GET | `/api/tasks` | 全タスク一覧（orderIndex 昇順） |
| GET | `/api/tasks?status={status}` | ステータスでフィルタ |
| GET | `/api/tasks/{id}` | ID で単体取得（存在しない場合 404） |

## Test plan
- [ ] Docker Compose で PostgreSQL 起動済みであること
- [ ] `./gradlew bootRun` でアプリが正常起動すること
- [ ] `curl http://localhost:8080/api/tasks` → 5件の JSON 配列が返ること
- [ ] `curl "http://localhost:8080/api/tasks?status=todo"` → 3件が返ること
- [ ] `curl http://localhost:8080/api/tasks/1` → 単体 JSON が返ること
- [ ] `curl -o /dev/null -w "%{http_code}" http://localhost:8080/api/tasks/999` → 404 が返ること

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)