### PR TITLE
feat: バックエンドにCORS設定を追加 (#6)

### DIFF
--- a/backend/src/main/java/com/example/taskmanagement/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/example/taskmanagement/config/WebMvcConfig.java
@@ -1,0 +1,18 @@
+package com.example.taskmanagement.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .maxAge(3600);
+    }
+}


### PR DESCRIPTION
## 概要

- `WebMvcConfig.java` を追加し、`/api/**` へのCORSリクエストを許可

## 変更内容

- `http://localhost:5173`（Viteフロントエンド）からの GET/POST/PUT/PATCH/DELETE/OPTIONS を許可
- `@CrossOrigin` ではなく `WebMvcConfigurer` を使い、全 `/api/**` エンドポイントを一括カバー

Closes #6