### PR TITLE
chore: TypeScriptを6.0.3にアップデート (#10)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "globals": "^17.5.0",
         "postcss": "^8.5.12",
         "tailwindcss": "^3.4.19",
-        "typescript": "~6.0.2",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.58.2",
         "vite": "^5.4.21"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "globals": "^17.5.0",
     "postcss": "^8.5.12",
     "tailwindcss": "^3.4.19",
-    "typescript": "~6.0.2",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.58.2",
     "vite": "^5.4.21"
   }


### PR DESCRIPTION
## 概要

- TypeScript 6.0.2 → 6.0.3（パッチバージョン、互換性変更なし）
- `npx tsc --noEmit` で型チェック通過確認済み

Closes #10