### PR TITLE
chore: .viteをfrontend/.gitignoreに追加 (#14)

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.vite
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## 変更内容

`frontend/.gitignore` に `.vite` を追加。

Viteが自動生成するキャッシュディレクトリのため、git管理対象から除外する。

Closes #14