### PR TITLE
feat: タスク新規登録機能を追加 (#16)

### DIFF
--- a/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
@@ -1,9 +1,12 @@
 package com.example.taskmanagement.controller;
 
+import com.example.taskmanagement.dto.TaskCreateRequestDto;
 import com.example.taskmanagement.dto.TaskResponseDto;
 import com.example.taskmanagement.service.TaskService;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.List;
 
@@ -29,5 +32,15 @@ public class TaskController {
     @GetMapping("/{id}")
     public ResponseEntity<TaskResponseDto> getTaskById(@PathVariable Integer id) {
         return ResponseEntity.ok(taskService.getTaskById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<TaskResponseDto> createTask(@Valid @RequestBody TaskCreateRequestDto request) {
+        TaskResponseDto created = taskService.createTask(request);
+        var location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(created.id())
+                .toUri();
+        return ResponseEntity.created(location).body(created);
     }
 }

--- a/backend/src/main/java/com/example/taskmanagement/dto/TaskCreateRequestDto.java
+++ b/backend/src/main/java/com/example/taskmanagement/dto/TaskCreateRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.taskmanagement.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record TaskCreateRequestDto(
+        @NotBlank @Size(max = 255) String title,
+        String description,
+        String status,
+        String priority,
+        LocalDate dueDate
+) {}

--- a/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
@@ -1,5 +1,6 @@
 package com.example.taskmanagement.service;
 
+import com.example.taskmanagement.dto.TaskCreateRequestDto;
 import com.example.taskmanagement.dto.TaskResponseDto;
 
 import java.util.List;
@@ -8,4 +9,5 @@ public interface TaskService {
     List<TaskResponseDto> getAllTasks();
     List<TaskResponseDto> getTasksByStatus(String status);
     TaskResponseDto getTaskById(Integer id);
+    TaskResponseDto createTask(TaskCreateRequestDto request);
 }

--- a/backend/src/main/java/com/example/taskmanagement/service/TaskServiceImpl.java
+++ b/backend/src/main/java/com/example/taskmanagement/service/TaskServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.taskmanagement.service;
 
+import com.example.taskmanagement.dto.TaskCreateRequestDto;
 import com.example.taskmanagement.dto.TaskResponseDto;
 import com.example.taskmanagement.entity.Task;
 import com.example.taskmanagement.exception.TaskNotFoundException;
@@ -40,6 +41,25 @@ public class TaskServiceImpl implements TaskService {
         Task task = taskRepository.findById(id)
                 .orElseThrow(() -> new TaskNotFoundException(id));
         return toDto(task);
+    }
+
+    @Override
+    @Transactional
+    public TaskResponseDto createTask(TaskCreateRequestDto request) {
+        int nextOrder = taskRepository.findAll().stream()
+                .mapToInt(Task::getOrderIndex)
+                .max()
+                .orElse(0) + 1;
+
+        Task task = new Task();
+        task.setTitle(request.title());
+        task.setDescription(request.description());
+        task.setStatus(request.status() != null ? request.status() : "todo");
+        task.setPriority(request.priority());
+        task.setDueDate(request.dueDate());
+        task.setOrderIndex(nextOrder);
+
+        return toDto(taskRepository.save(task));
     }
 
     private TaskResponseDto toDto(Task task) {

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.vite
 
 # Editor directories and files
 .vscode/*

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState } from "react";
 import type { Task } from "./types/task";
-import { fetchAllTasks } from "./api/taskApi";
+import { fetchAllTasks, createTask } from "./api/taskApi";
+import type { CreateTaskRequest } from "./api/taskApi";
 import Header from "./components/Header";
 import KanbanBoard from "./components/KanbanBoard";
+import TaskCreateModal from "./components/TaskCreateModal";
 
 export default function App() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showCreateModal, setShowCreateModal] = useState(false);
 
   useEffect(() => {
     fetchAllTasks()
@@ -16,9 +19,14 @@ export default function App() {
       .finally(() => setLoading(false));
   }, []);
 
+  async function handleCreateTask(request: CreateTaskRequest) {
+    const newTask = await createTask(request);
+    setTasks((prev) => [...prev, newTask]);
+  }
+
   return (
     <div className="flex flex-col min-h-screen">
-      <Header />
+      <Header onCreateTask={() => setShowCreateModal(true)} />
       {loading && (
         <div className="flex-1 flex items-center justify-center text-gray-500">
           読み込み中...
@@ -30,6 +38,12 @@ export default function App() {
         </div>
       )}
       {!loading && !error && <KanbanBoard tasks={tasks} />}
+      {showCreateModal && (
+        <TaskCreateModal
+          onClose={() => setShowCreateModal(false)}
+          onSubmit={handleCreateTask}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/api/taskApi.ts
+++ b/frontend/src/api/taskApi.ts
@@ -1,9 +1,27 @@
-import type { Task } from "../types/task";
+import type { Task, TaskPriority, TaskStatus } from "../types/task";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
 
 export async function fetchAllTasks(): Promise<Task[]> {
   const res = await fetch(`${BASE_URL}/api/tasks`);
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+export interface CreateTaskRequest {
+  title: string;
+  description?: string;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  dueDate?: string;
+}
+
+export async function createTask(request: CreateTaskRequest): Promise<Task> {
+  const res = await fetch(`${BASE_URL}/api/tasks`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,7 +1,20 @@
-export default function Header() {
+interface Props {
+  onCreateTask?: () => void;
+}
+
+export default function Header({ onCreateTask }: Props) {
   return (
-    <header className="bg-[#1e2a3a] h-14 flex items-center px-6 shadow-md flex-shrink-0">
+    <header className="bg-[#1e2a3a] h-14 flex items-center justify-between px-6 shadow-md flex-shrink-0">
       <h1 className="text-white text-xl font-bold tracking-wide">TaskManagement</h1>
+      {onCreateTask && (
+        <button
+          onClick={onCreateTask}
+          className="flex items-center gap-1.5 bg-blue-500 hover:bg-blue-400 text-white text-sm font-medium px-4 py-1.5 rounded-lg transition-colors"
+        >
+          <span className="text-lg leading-none">＋</span>
+          新規作成
+        </button>
+      )}
     </header>
   );
 }

--- a/frontend/src/components/TaskCreateModal.tsx
+++ b/frontend/src/components/TaskCreateModal.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import type { TaskPriority, TaskStatus } from "../types/task";
+import type { CreateTaskRequest } from "../api/taskApi";
+
+interface Props {
+  onClose: () => void;
+  onSubmit: (request: CreateTaskRequest) => Promise<void>;
+}
+
+export default function TaskCreateModal({ onClose, onSubmit }: Props) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [status, setStatus] = useState<TaskStatus>("todo");
+  const [priority, setPriority] = useState<TaskPriority | "">("");
+  const [dueDate, setDueDate] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit({
+        title: title.trim(),
+        description: description.trim() || undefined,
+        status,
+        priority: priority || undefined,
+        dueDate: dueDate || undefined,
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "登録に失敗しました");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-md mx-4 p-6">
+        <h2 className="text-lg font-bold text-gray-800 mb-5">タスクを新規登録</h2>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              タイトル <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="タスクのタイトル"
+              maxLength={255}
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">説明</label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              placeholder="タスクの詳細（任意）"
+              rows={3}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">ステータス</label>
+              <select
+                value={status}
+                onChange={(e) => setStatus(e.target.value as TaskStatus)}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="todo">未着手</option>
+                <option value="in_progress">進行中</option>
+                <option value="done">完了</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">優先度</label>
+              <select
+                value={priority}
+                onChange={(e) => setPriority(e.target.value as TaskPriority | "")}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="">なし</option>
+                <option value="low">低</option>
+                <option value="medium">中</option>
+                <option value="high">高</option>
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">期日</label>
+            <input
+              type="date"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-500">{error}</p>
+          )}
+
+          <div className="flex justify-end gap-3 mt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || !title.trim()}
+              className="px-4 py-2 text-sm rounded-lg bg-blue-600 text-white font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting ? "登録中..." : "登録"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #16

## Summary
- `POST /api/tasks` エンドポイントを追加（`TaskCreateRequestDto` → Service → Controller）
- フロントエンドに「新規作成」ボタンとモーダルを追加し、登録後カンバンボードに即時反映
- 登録タスクは PostgreSQL に永続化（アプリ再起動後も保持）

## Test plan
- [x] `curl -X POST http://localhost:8080/api/tasks` でタスク登録、201 レスポンスと登録データを確認
- [x] DB（`SELECT * FROM tasks`）で登録レコードが存在することを確認
- [x] 画面の「新規作成」ボタンからモーダルを開き、フォーム入力して登録できることを確認
- [x] 登録後、カンバンボードに即時反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)