### PR TITLE
feat: タスク追加ボタンを未着手カラム下部へ移動 (#18)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,7 +26,7 @@ export default function App() {
 
   return (
     <div className="flex flex-col min-h-screen">
-      <Header onCreateTask={() => setShowCreateModal(true)} />
+      <Header />
       {loading && (
         <div className="flex-1 flex items-center justify-center text-gray-500">
           読み込み中...
@@ -37,7 +37,7 @@ export default function App() {
           エラー: {error}
         </div>
       )}
-      {!loading && !error && <KanbanBoard tasks={tasks} />}
+      {!loading && !error && <KanbanBoard tasks={tasks} onAddTask={() => setShowCreateModal(true)} />}
       {showCreateModal && (
         <TaskCreateModal
           onClose={() => setShowCreateModal(false)}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,20 +1,7 @@
-interface Props {
-  onCreateTask?: () => void;
-}
-
-export default function Header({ onCreateTask }: Props) {
+export default function Header() {
   return (
-    <header className="bg-[#1e2a3a] h-14 flex items-center justify-between px-6 shadow-md flex-shrink-0">
+    <header className="bg-[#1e2a3a] h-14 flex items-center px-6 shadow-md flex-shrink-0">
       <h1 className="text-white text-xl font-bold tracking-wide">TaskManagement</h1>
-      {onCreateTask && (
-        <button
-          onClick={onCreateTask}
-          className="flex items-center gap-1.5 bg-blue-500 hover:bg-blue-400 text-white text-sm font-medium px-4 py-1.5 rounded-lg transition-colors"
-        >
-          <span className="text-lg leading-none">＋</span>
-          新規作成
-        </button>
-      )}
     </header>
   );
 }

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -9,9 +9,10 @@ const COLUMNS: { status: TaskStatus; label: string }[] = [
 
 interface Props {
   tasks: Task[];
+  onAddTask: () => void;
 }
 
-export default function KanbanBoard({ tasks }: Props) {
+export default function KanbanBoard({ tasks, onAddTask }: Props) {
   const grouped = Object.fromEntries(
     COLUMNS.map(({ status }) => [
       status,
@@ -22,7 +23,12 @@ export default function KanbanBoard({ tasks }: Props) {
   return (
     <div className="flex gap-5 p-6 overflow-x-auto items-start flex-1 bg-[#f4f5f7]">
       {COLUMNS.map(({ status, label }) => (
-        <KanbanColumn key={status} label={label} tasks={grouped[status]} />
+        <KanbanColumn
+          key={status}
+          label={label}
+          tasks={grouped[status]}
+          onAddTask={status === "todo" ? onAddTask : undefined}
+        />
       ))}
     </div>
   );

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -4,9 +4,10 @@ import TaskCard from "./TaskCard";
 interface Props {
   label: string;
   tasks: Task[];
+  onAddTask?: () => void;
 }
 
-export default function KanbanColumn({ label, tasks }: Props) {
+export default function KanbanColumn({ label, tasks, onAddTask }: Props) {
   return (
     <div className="flex-none w-72 bg-[#ebecf0] rounded-lg p-3 flex flex-col gap-2">
       <div className="flex items-center justify-between px-1 pb-1">
@@ -20,6 +21,15 @@ export default function KanbanColumn({ label, tasks }: Props) {
           <TaskCard key={task.id} task={task} />
         ))}
       </div>
+      {onAddTask && (
+        <button
+          onClick={onAddTask}
+          className="flex items-center gap-1.5 text-gray-500 hover:text-gray-700 hover:bg-[#dcdfe4] text-sm px-2 py-1.5 rounded-md transition-colors mt-1"
+        >
+          <span className="text-base leading-none">＋</span>
+          タスクを追加
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #18

## Summary
- ヘッダー右上の「新規作成」ボタンを削除
- 未着手（todo）カラムの一番下に「＋ タスクを追加」ボタンを追加
- ボタン押下で登録モーダルが開き、登録後カンバンボードに即時反映

## Test plan
- [x] ヘッダーにボタンがないことを確認
- [x] 未着手カラムの一番下に「＋ タスクを追加」ボタンが表示されることを確認
- [x] ボタンから登録モーダルが開き、タスクを登録できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)