### PR TITLE
feat: タスク更新・並び替えAPIを実装 (#20)

### DIFF
--- a/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
@@ -1,7 +1,9 @@
 package com.example.taskmanagement.controller;
 
 import com.example.taskmanagement.dto.TaskCreateRequestDto;
+import com.example.taskmanagement.dto.TaskReorderItemDto;
 import com.example.taskmanagement.dto.TaskResponseDto;
+import com.example.taskmanagement.dto.TaskUpdateRequestDto;
 import com.example.taskmanagement.service.TaskService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -42,5 +44,18 @@ public class TaskController {
                 .buildAndExpand(created.id())
                 .toUri();
         return ResponseEntity.created(location).body(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<TaskResponseDto> updateTask(
+            @PathVariable Integer id,
+            @Valid @RequestBody TaskUpdateRequestDto request) {
+        return ResponseEntity.ok(taskService.updateTask(id, request));
+    }
+
+    @PostMapping("/reorder")
+    public ResponseEntity<Void> reorderTasks(@RequestBody List<TaskReorderItemDto> items) {
+        taskService.reorderTasks(items);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/example/taskmanagement/dto/TaskReorderItemDto.java
+++ b/backend/src/main/java/com/example/taskmanagement/dto/TaskReorderItemDto.java
@@ -1,0 +1,9 @@
+package com.example.taskmanagement.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record TaskReorderItemDto(
+        @NotNull Integer id,
+        @NotNull Integer orderIndex,
+        String status
+) {}

--- a/backend/src/main/java/com/example/taskmanagement/dto/TaskUpdateRequestDto.java
+++ b/backend/src/main/java/com/example/taskmanagement/dto/TaskUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.taskmanagement.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record TaskUpdateRequestDto(
+        @NotBlank @Size(max = 255) String title,
+        String description,
+        String status,
+        String priority,
+        LocalDate dueDate
+) {}

--- a/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
@@ -1,7 +1,9 @@
 package com.example.taskmanagement.service;
 
 import com.example.taskmanagement.dto.TaskCreateRequestDto;
+import com.example.taskmanagement.dto.TaskReorderItemDto;
 import com.example.taskmanagement.dto.TaskResponseDto;
+import com.example.taskmanagement.dto.TaskUpdateRequestDto;
 
 import java.util.List;
 
@@ -10,4 +12,6 @@ public interface TaskService {
     List<TaskResponseDto> getTasksByStatus(String status);
     TaskResponseDto getTaskById(Integer id);
     TaskResponseDto createTask(TaskCreateRequestDto request);
+    TaskResponseDto updateTask(Integer id, TaskUpdateRequestDto request);
+    void reorderTasks(List<TaskReorderItemDto> items);
 }

--- a/backend/src/main/java/com/example/taskmanagement/service/TaskServiceImpl.java
+++ b/backend/src/main/java/com/example/taskmanagement/service/TaskServiceImpl.java
@@ -1,7 +1,9 @@
 package com.example.taskmanagement.service;
 
 import com.example.taskmanagement.dto.TaskCreateRequestDto;
+import com.example.taskmanagement.dto.TaskReorderItemDto;
 import com.example.taskmanagement.dto.TaskResponseDto;
+import com.example.taskmanagement.dto.TaskUpdateRequestDto;
 import com.example.taskmanagement.entity.Task;
 import com.example.taskmanagement.exception.TaskNotFoundException;
 import com.example.taskmanagement.repository.TaskRepository;
@@ -9,6 +11,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -60,6 +64,34 @@ public class TaskServiceImpl implements TaskService {
         task.setOrderIndex(nextOrder);
 
         return toDto(taskRepository.save(task));
+    }
+
+    @Override
+    @Transactional
+    public TaskResponseDto updateTask(Integer id, TaskUpdateRequestDto request) {
+        Task task = taskRepository.findById(id)
+                .orElseThrow(() -> new TaskNotFoundException(id));
+        task.setTitle(request.title());
+        task.setDescription(request.description());
+        if (request.status() != null) task.setStatus(request.status());
+        task.setPriority(request.priority());
+        task.setDueDate(request.dueDate());
+        return toDto(taskRepository.save(task));
+    }
+
+    @Override
+    @Transactional
+    public void reorderTasks(List<TaskReorderItemDto> items) {
+        List<Integer> ids = items.stream().map(TaskReorderItemDto::id).toList();
+        Map<Integer, Task> taskMap = taskRepository.findAllById(ids).stream()
+                .collect(Collectors.toMap(Task::getId, t -> t));
+        for (TaskReorderItemDto item : items) {
+            Task task = taskMap.get(item.id());
+            if (task == null) throw new TaskNotFoundException(item.id());
+            task.setOrderIndex(item.orderIndex());
+            if (item.status() != null) task.setStatus(item.status());
+        }
+        taskRepository.saveAll(taskMap.values());
     }
 
     private TaskResponseDto toDto(Task task) {


### PR DESCRIPTION
## 概要
タスクの更新・並び替えAPIを実装した。

## 変更内容
- `TaskUpdateRequestDto` 追加（title・description・status・priority・dueDate）
- `TaskReorderItemDto` 追加（id・orderIndex・status の一括更新用）
- `TaskService` に `updateTask` / `reorderTasks` メソッドを追加
- `PUT /api/tasks/{id}` エンドポイント追加
- `POST /api/tasks/reorder` エンドポイント追加（バッチ更新でパフォーマンス最適化）

Closes #20