### PR TITLE
feat: タスク詳細モーダル・ステータス更新・ドラッグ&ドロップ並び替えを実装 (#21)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,7 +37,13 @@ export default function App() {
           エラー: {error}
         </div>
       )}
-      {!loading && !error && <KanbanBoard tasks={tasks} onAddTask={() => setShowCreateModal(true)} />}
+      {!loading && !error && (
+        <KanbanBoard
+          tasks={tasks}
+          onTasksChange={setTasks}
+          onAddTask={() => setShowCreateModal(true)}
+        />
+      )}
       {showCreateModal && (
         <TaskCreateModal
           onClose={() => setShowCreateModal(false)}

--- a/frontend/src/api/taskApi.ts
+++ b/frontend/src/api/taskApi.ts
@@ -1,4 +1,4 @@
-import type { Task, TaskPriority, TaskStatus } from "../types/task";
+import type { Task, TaskPriority, TaskReorderItem, TaskStatus, TaskUpdateRequest } from "../types/task";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
 
@@ -24,4 +24,23 @@ export async function createTask(request: CreateTaskRequest): Promise<Task> {
   });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();
+}
+
+export async function updateTask(id: number, request: TaskUpdateRequest): Promise<Task> {
+  const res = await fetch(`${BASE_URL}/api/tasks/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+export async function reorderTasks(items: TaskReorderItem[]): Promise<void> {
+  const res = await fetch(`${BASE_URL}/api/tasks/reorder`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(items),
+  });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
 }

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -1,35 +1,155 @@
-import type { Task, TaskStatus } from "../types/task";
+import { useRef, useState } from "react";
+import type { Task, TaskReorderItem, TaskStatus, TaskUpdateRequest } from "../types/task";
+import { reorderTasks, updateTask } from "../api/taskApi";
 import KanbanColumn from "./KanbanColumn";
+import TaskDetailModal from "./TaskDetailModal";
 
 const COLUMNS: { status: TaskStatus; label: string }[] = [
-  { status: "todo",        label: "未着手" },
+  { status: "todo", label: "未着手" },
   { status: "in_progress", label: "進行中" },
-  { status: "done",        label: "完了" },
+  { status: "done", label: "完了" },
 ];
+
+interface DropIndicator {
+  beforeTaskId: number | null;
+  status: TaskStatus;
+}
 
 interface Props {
   tasks: Task[];
+  onTasksChange: (tasks: Task[]) => void;
   onAddTask: () => void;
 }
 
-export default function KanbanBoard({ tasks, onAddTask }: Props) {
+export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) {
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+  const [draggingId, setDraggingId] = useState<number | null>(null);
+  const [dropIndicator, setDropIndicator] = useState<DropIndicator | null>(null);
+  const dragIdRef = useRef<number | null>(null);
+
   const grouped = Object.fromEntries(
     COLUMNS.map(({ status }) => [
       status,
-      tasks.filter((t) => t.status === status),
+      [...tasks.filter((t) => t.status === status)].sort(
+        (a, b) => a.orderIndex - b.orderIndex
+      ),
     ])
   ) as Record<TaskStatus, Task[]>;
 
+  function handleDragStart(taskId: number) {
+    dragIdRef.current = taskId;
+    setDraggingId(taskId);
+  }
+
+  function handleDragEnd() {
+    dragIdRef.current = null;
+    setDraggingId(null);
+    setDropIndicator(null);
+  }
+
+  function handleDragOverColumn(status: TaskStatus) {
+    setDropIndicator({ beforeTaskId: null, status });
+  }
+
+  function handleDragOverCard(taskId: number, status: TaskStatus, above: boolean) {
+    if (above) {
+      setDropIndicator({ beforeTaskId: taskId, status });
+    } else {
+      const colTasks = grouped[status];
+      const idx = colTasks.findIndex((t) => t.id === taskId);
+      const next = colTasks[idx + 1];
+      setDropIndicator({ beforeTaskId: next ? next.id : null, status });
+    }
+  }
+
+  function handleDrop(targetStatus: TaskStatus) {
+    const id = dragIdRef.current;
+    if (id == null) return;
+
+    const dragged = tasks.find((t) => t.id === id);
+    if (!dragged) return;
+
+    const targetColTasks = grouped[targetStatus].filter((t) => t.id !== id);
+    const insertBefore = dropIndicator?.beforeTaskId ?? null;
+
+    let insertIdx = targetColTasks.length;
+    if (insertBefore != null) {
+      const idx = targetColTasks.findIndex((t) => t.id === insertBefore);
+      if (idx !== -1) insertIdx = idx;
+    }
+
+    targetColTasks.splice(insertIdx, 0, { ...dragged, status: targetStatus });
+
+    const reorderItems: TaskReorderItem[] = [];
+
+    // Recalculate target column orderIndex
+    targetColTasks.forEach((t, i) => {
+      reorderItems.push({ id: t.id, orderIndex: i, status: targetStatus });
+    });
+
+    // Recalculate source column if different
+    if (dragged.status !== targetStatus) {
+      grouped[dragged.status]
+        .filter((t) => t.id !== id)
+        .forEach((t, i) => {
+          reorderItems.push({ id: t.id, orderIndex: i, status: dragged.status });
+        });
+    }
+
+    // Apply optimistic update
+    const updatedMap = new Map(reorderItems.map((r) => [r.id, r]));
+    const nextTasks = tasks.map((t) => {
+      const updated = updatedMap.get(t.id);
+      if (updated) return { ...t, orderIndex: updated.orderIndex, status: updated.status };
+      return t;
+    });
+    onTasksChange(nextTasks);
+
+    setDraggingId(null);
+    setDropIndicator(null);
+    dragIdRef.current = null;
+
+    reorderTasks(reorderItems).catch(() => {
+      // Revert on failure
+      onTasksChange(tasks);
+    });
+  }
+
+  async function handleSaveTask(id: number, request: TaskUpdateRequest) {
+    const updated = await updateTask(id, request);
+    onTasksChange(tasks.map((t) => (t.id === id ? updated : t)));
+    setSelectedTask(updated);
+  }
+
   return (
-    <div className="flex gap-5 p-6 overflow-x-auto items-start flex-1 bg-[#f4f5f7]">
-      {COLUMNS.map(({ status, label }) => (
-        <KanbanColumn
-          key={status}
-          label={label}
-          tasks={grouped[status]}
-          onAddTask={status === "todo" ? onAddTask : undefined}
+    <>
+      <div className="flex gap-5 p-6 overflow-x-auto items-start flex-1 bg-[#f4f5f7]">
+        {COLUMNS.map(({ status, label }) => (
+          <KanbanColumn
+            key={status}
+            label={label}
+            status={status}
+            tasks={grouped[status]}
+            draggingId={draggingId}
+            dropIndicator={dropIndicator}
+            onAddTask={status === "todo" ? onAddTask : undefined}
+            onTaskClick={setSelectedTask}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            onDragOverColumn={handleDragOverColumn}
+            onDragOverCard={handleDragOverCard}
+            onDrop={handleDrop}
+          />
+        ))}
+      </div>
+
+      {selectedTask && (
+        <TaskDetailModal
+          task={selectedTask}
+          onClose={() => setSelectedTask(null)}
+          onSave={handleSaveTask}
         />
-      ))}
-    </div>
+      )}
+    </>
   );
 }

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -1,26 +1,94 @@
-import type { Task } from "../types/task";
+import type { Task, TaskStatus } from "../types/task";
 import TaskCard from "./TaskCard";
+
+interface DropIndicator {
+  beforeTaskId: number | null;
+  status: TaskStatus;
+}
 
 interface Props {
   label: string;
+  status: TaskStatus;
   tasks: Task[];
+  draggingId: number | null;
+  dropIndicator: DropIndicator | null;
   onAddTask?: () => void;
+  onTaskClick: (task: Task) => void;
+  onDragStart: (taskId: number) => void;
+  onDragEnd: () => void;
+  onDragOverColumn: (status: TaskStatus) => void;
+  onDragOverCard: (taskId: number, status: TaskStatus, above: boolean) => void;
+  onDrop: (status: TaskStatus) => void;
 }
 
-export default function KanbanColumn({ label, tasks, onAddTask }: Props) {
+export default function KanbanColumn({
+  label,
+  status,
+  tasks,
+  draggingId,
+  dropIndicator,
+  onAddTask,
+  onTaskClick,
+  onDragStart,
+  onDragEnd,
+  onDragOverColumn,
+  onDragOverCard,
+  onDrop,
+}: Props) {
+  const isDropTarget = dropIndicator?.status === status;
+
+  function handleDragOver(e: React.DragEvent) {
+    e.preventDefault();
+    onDragOverColumn(status);
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    onDrop(status);
+  }
+
+  const showEndIndicator =
+    isDropTarget && dropIndicator?.beforeTaskId == null;
+
   return (
-    <div className="flex-none w-72 bg-[#ebecf0] rounded-lg p-3 flex flex-col gap-2">
+    <div
+      className={`flex-none w-72 rounded-lg p-3 flex flex-col gap-2 transition-colors ${
+        isDropTarget ? "bg-[#dfe1e6]" : "bg-[#ebecf0]"
+      }`}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
       <div className="flex items-center justify-between px-1 pb-1">
         <span className="font-bold text-sm text-gray-700">{label}</span>
         <span className="bg-[#c2c7d0] text-xs font-bold px-2 py-0.5 rounded-full min-w-[22px] text-center text-gray-600">
           {tasks.length}
         </span>
       </div>
-      <div className="flex flex-col gap-2">
-        {tasks.map((task) => (
-          <TaskCard key={task.id} task={task} />
-        ))}
+
+      <div className="flex flex-col">
+        {tasks.map((task) => {
+          const showAbove =
+            isDropTarget && dropIndicator?.beforeTaskId === task.id;
+
+          return (
+            <div key={task.id}>
+              {showAbove && <DropLine />}
+              <div className="mb-2">
+                <TaskCard
+                  task={task}
+                  isDragging={task.id === draggingId}
+                  onClick={() => onTaskClick(task)}
+                  onDragStart={() => onDragStart(task.id)}
+                  onDragEnd={onDragEnd}
+                  onDragOver={(above) => onDragOverCard(task.id, status, above)}
+                />
+              </div>
+            </div>
+          );
+        })}
+        {showEndIndicator && <DropLine />}
       </div>
+
       {onAddTask && (
         <button
           onClick={onAddTask}
@@ -31,5 +99,11 @@ export default function KanbanColumn({ label, tasks, onAddTask }: Props) {
         </button>
       )}
     </div>
+  );
+}
+
+function DropLine() {
+  return (
+    <div className="h-0.5 bg-blue-400 rounded-full mx-1 mb-2 shadow-sm" />
   );
 }

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -13,14 +13,46 @@ function formatDate(iso: string): string {
 
 interface Props {
   task: Task;
+  isDragging: boolean;
+  onClick: () => void;
+  onDragStart: () => void;
+  onDragEnd: () => void;
+  onDragOver: (above: boolean) => void;
 }
 
-export default function TaskCard({ task }: Props) {
+export default function TaskCard({
+  task,
+  isDragging,
+  onClick,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+}: Props) {
   const priority = task.priority ? PRIORITY_MAP[task.priority] : null;
   const hasMeta = priority !== null || task.dueDate !== null;
 
+  function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    e.stopPropagation();
+    const rect = e.currentTarget.getBoundingClientRect();
+    const midY = rect.top + rect.height / 2;
+    onDragOver(e.clientY < midY);
+  }
+
   return (
-    <div className="bg-white rounded-md shadow-sm p-3 cursor-default">
+    <div
+      draggable
+      onClick={onClick}
+      onDragStart={(e) => {
+        e.stopPropagation();
+        onDragStart();
+      }}
+      onDragEnd={onDragEnd}
+      onDragOver={handleDragOver}
+      className={`bg-white rounded-md shadow-sm p-3 cursor-pointer select-none transition-opacity hover:shadow-md ${
+        isDragging ? "opacity-40" : "opacity-100"
+      }`}
+    >
       <p className="text-sm font-medium text-gray-800 leading-snug">{task.title}</p>
       {hasMeta && (
         <div className="flex items-center gap-2 mt-2">

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useRef, useState } from "react";
+import type { Task, TaskPriority, TaskStatus, TaskUpdateRequest } from "../types/task";
+
+const STATUS_OPTIONS: { value: TaskStatus; label: string }[] = [
+  { value: "todo", label: "未着手" },
+  { value: "in_progress", label: "進行中" },
+  { value: "done", label: "完了" },
+];
+
+const PRIORITY_OPTIONS: { value: TaskPriority | ""; label: string }[] = [
+  { value: "", label: "なし" },
+  { value: "low", label: "低" },
+  { value: "medium", label: "中" },
+  { value: "high", label: "高" },
+];
+
+interface Props {
+  task: Task;
+  onClose: () => void;
+  onSave: (id: number, request: TaskUpdateRequest) => Promise<void>;
+}
+
+export default function TaskDetailModal({ task, onClose, onSave }: Props) {
+  const [title, setTitle] = useState(task.title);
+  const [description, setDescription] = useState(task.description ?? "");
+  const [status, setStatus] = useState<TaskStatus>(task.status);
+  const [priority, setPriority] = useState<TaskPriority | "">(task.priority ?? "");
+  const [dueDate, setDueDate] = useState(task.dueDate ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === e.currentTarget) onClose();
+  }
+
+  async function handleSave() {
+    if (!title.trim()) {
+      setError("タイトルは必須です");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(task.id, {
+        title: title.trim(),
+        description: description.trim() || null,
+        status,
+        priority: priority || null,
+        dueDate: dueDate || null,
+      });
+      onClose();
+    } catch {
+      setError("保存に失敗しました");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") onClose();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg flex flex-col max-h-[90vh]">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <h2 className="text-base font-bold text-gray-800">タスク詳細</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 text-xl leading-none px-1"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="overflow-y-auto flex-1 px-6 py-5 flex flex-col gap-4">
+          {error && (
+            <p className="text-sm text-red-600 bg-red-50 rounded-md px-3 py-2">{error}</p>
+          )}
+
+          {/* Title */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+              タイトル <span className="text-red-500">*</span>
+            </label>
+            <input
+              ref={titleRef}
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-transparent"
+              placeholder="タスクのタイトル"
+            />
+          </div>
+
+          {/* Description */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+              説明
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={4}
+              className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-transparent resize-none"
+              placeholder="説明を入力（任意）"
+            />
+          </div>
+
+          {/* Status & Priority */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                ステータス
+              </label>
+              <select
+                value={status}
+                onChange={(e) => setStatus(e.target.value as TaskStatus)}
+                className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-transparent bg-white"
+              >
+                {STATUS_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                優先度
+              </label>
+              <select
+                value={priority}
+                onChange={(e) => setPriority(e.target.value as TaskPriority | "")}
+                className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-transparent bg-white"
+              >
+                {PRIORITY_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Due Date */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+              期日
+            </label>
+            <input
+              type="date"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-transparent w-full"
+            />
+          </div>
+
+          {/* Metadata */}
+          <div className="text-xs text-gray-400 pt-1 border-t border-gray-100 flex gap-4">
+            <span>作成: {new Date(task.createdAt).toLocaleDateString("ja-JP")}</span>
+            <span>更新: {new Date(task.updatedAt).toLocaleDateString("ja-JP")}</span>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 px-6 py-4 border-t border-gray-200">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="px-4 py-2 text-sm font-semibold bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {saving ? "保存中..." : "保存"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -12,3 +12,17 @@ export interface Task {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface TaskUpdateRequest {
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  priority: TaskPriority | null;
+  dueDate: string | null;
+}
+
+export interface TaskReorderItem {
+  id: number;
+  orderIndex: number;
+  status: TaskStatus;
+}


### PR DESCRIPTION
## 概要
タスク詳細・編集モーダルと、ドラッグ&ドロップによるカラム間移動・並び替えを実装した。

## 変更内容

### 新規ファイル
- `TaskDetailModal.tsx` — タスク全フィールドの表示・編集・保存モーダル

### 更新ファイル
- `types/task.ts` — `TaskUpdateRequest`・`TaskReorderItem` 型を追加
- `api/taskApi.ts` — `updateTask` / `reorderTasks` 関数を追加
- `KanbanBoard.tsx` — ドラッグ状態管理・詳細モーダル制御を追加
- `KanbanColumn.tsx` — ドロップゾーン対応・ドロップインジケーター表示
- `TaskCard.tsx` — draggable対応・クリックで詳細モーダルを開く
- `App.tsx` — `onTasksChange` コールバックを追加

## 機能詳細
- タスクカードをクリック → 詳細・編集モーダルが開く
- モーダルでタイトル・説明・ステータス・優先度・期日を編集して保存
- ステータス変更も詳細モーダルから可能
- カード間でドラッグするとカード上半分/下半分でドロップ位置を検出
- 青いラインでドロップ挿入位置を表示
- カラム間移動でステータスが自動更新される
- 楽観的UI更新（即座に反映、失敗時はロールバック）

Closes #21