### PR TITLE
feat: カラムヘッダーに優先度・期限の並び替えボタンを追加 (#24)

### DIFF
--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -10,9 +10,35 @@ const COLUMNS: { status: TaskStatus; label: string }[] = [
   { status: "done", label: "完了" },
 ];
 
+export type SortKey = "priority" | "dueDate";
+
+interface SortState {
+  key: SortKey | null;
+  asc: boolean;
+}
+
 interface DropIndicator {
   beforeTaskId: number | null;
   status: TaskStatus;
+}
+
+const PRIORITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 };
+
+function sortColumnTasks(tasks: Task[], sort: SortState): Task[] {
+  if (!sort.key) return tasks;
+  return [...tasks].sort((a, b) => {
+    if (sort.key === "priority") {
+      const aVal = a.priority != null ? (PRIORITY_ORDER[a.priority] ?? 3) : 3;
+      const bVal = b.priority != null ? (PRIORITY_ORDER[b.priority] ?? 3) : 3;
+      return sort.asc ? aVal - bVal : bVal - aVal;
+    } else {
+      if (!a.dueDate && !b.dueDate) return 0;
+      if (!a.dueDate) return sort.asc ? 1 : -1;
+      if (!b.dueDate) return sort.asc ? -1 : 1;
+      const cmp = a.dueDate.localeCompare(b.dueDate);
+      return sort.asc ? cmp : -cmp;
+    }
+  });
 }
 
 interface Props {
@@ -25,16 +51,48 @@ export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) 
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [draggingId, setDraggingId] = useState<number | null>(null);
   const [dropIndicator, setDropIndicator] = useState<DropIndicator | null>(null);
+  const [sortStates, setSortStates] = useState<Record<TaskStatus, SortState>>({
+    todo: { key: null, asc: true },
+    in_progress: { key: null, asc: true },
+    done: { key: null, asc: true },
+  });
   const dragIdRef = useRef<number | null>(null);
 
   const grouped = Object.fromEntries(
-    COLUMNS.map(({ status }) => [
-      status,
-      [...tasks.filter((t) => t.status === status)].sort(
+    COLUMNS.map(({ status }) => {
+      const colTasks = [...tasks.filter((t) => t.status === status)].sort(
         (a, b) => a.orderIndex - b.orderIndex
-      ),
-    ])
+      );
+      return [status, sortColumnTasks(colTasks, sortStates[status])];
+    })
   ) as Record<TaskStatus, Task[]>;
+
+  function handleSort(status: TaskStatus, key: SortKey) {
+    const current = sortStates[status];
+    const asc = current.key === key ? !current.asc : true;
+    const newSort: SortState = { key, asc };
+
+    setSortStates((prev) => ({ ...prev, [status]: newSort }));
+
+    const colTasks = [...tasks.filter((t) => t.status === status)].sort(
+      (a, b) => a.orderIndex - b.orderIndex
+    );
+    const sorted = sortColumnTasks(colTasks, newSort);
+    const reorderItems: TaskReorderItem[] = sorted.map((t, i) => ({
+      id: t.id,
+      orderIndex: i,
+      status: t.status,
+    }));
+
+    const updatedMap = new Map(reorderItems.map((r) => [r.id, r]));
+    const nextTasks = tasks.map((t) => {
+      const updated = updatedMap.get(t.id);
+      return updated ? { ...t, orderIndex: updated.orderIndex } : t;
+    });
+    onTasksChange(nextTasks);
+
+    reorderTasks(reorderItems).catch(() => onTasksChange(tasks));
+  }
 
   function handleDragStart(taskId: number) {
     dragIdRef.current = taskId;
@@ -81,13 +139,10 @@ export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) 
     targetColTasks.splice(insertIdx, 0, { ...dragged, status: targetStatus });
 
     const reorderItems: TaskReorderItem[] = [];
-
-    // Recalculate target column orderIndex
     targetColTasks.forEach((t, i) => {
       reorderItems.push({ id: t.id, orderIndex: i, status: targetStatus });
     });
 
-    // Recalculate source column if different
     if (dragged.status !== targetStatus) {
       grouped[dragged.status]
         .filter((t) => t.id !== id)
@@ -96,7 +151,6 @@ export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) 
         });
     }
 
-    // Apply optimistic update
     const updatedMap = new Map(reorderItems.map((r) => [r.id, r]));
     const nextTasks = tasks.map((t) => {
       const updated = updatedMap.get(t.id);
@@ -105,14 +159,22 @@ export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) 
     });
     onTasksChange(nextTasks);
 
+    // ドラッグ後はそのカラムのソートをリセット
+    if (dragged.status !== targetStatus) {
+      setSortStates((prev) => ({
+        ...prev,
+        [targetStatus]: { key: null, asc: true },
+        [dragged.status]: { key: null, asc: true },
+      }));
+    } else {
+      setSortStates((prev) => ({ ...prev, [targetStatus]: { key: null, asc: true } }));
+    }
+
     setDraggingId(null);
     setDropIndicator(null);
     dragIdRef.current = null;
 
-    reorderTasks(reorderItems).catch(() => {
-      // Revert on failure
-      onTasksChange(tasks);
-    });
+    reorderTasks(reorderItems).catch(() => onTasksChange(tasks));
   }
 
   async function handleSaveTask(id: number, request: TaskUpdateRequest) {
@@ -132,6 +194,8 @@ export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) 
             tasks={grouped[status]}
             draggingId={draggingId}
             dropIndicator={dropIndicator}
+            sortState={sortStates[status]}
+            onSort={(key) => handleSort(status, key)}
             onAddTask={status === "todo" ? onAddTask : undefined}
             onTaskClick={setSelectedTask}
             onDragStart={handleDragStart}

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -1,5 +1,11 @@
 import type { Task, TaskStatus } from "../types/task";
+import type { SortKey } from "./KanbanBoard";
 import TaskCard from "./TaskCard";
+
+interface SortState {
+  key: SortKey | null;
+  asc: boolean;
+}
 
 interface DropIndicator {
   beforeTaskId: number | null;
@@ -12,6 +18,8 @@ interface Props {
   tasks: Task[];
   draggingId: number | null;
   dropIndicator: DropIndicator | null;
+  sortState: SortState;
+  onSort: (key: SortKey) => void;
   onAddTask?: () => void;
   onTaskClick: (task: Task) => void;
   onDragStart: (taskId: number) => void;
@@ -21,12 +29,19 @@ interface Props {
   onDrop: (status: TaskStatus) => void;
 }
 
+const SORT_BUTTONS: { key: SortKey; label: string }[] = [
+  { key: "priority", label: "優先度" },
+  { key: "dueDate", label: "期限" },
+];
+
 export default function KanbanColumn({
   label,
   status,
   tasks,
   draggingId,
   dropIndicator,
+  sortState,
+  onSort,
   onAddTask,
   onTaskClick,
   onDragStart,
@@ -47,8 +62,7 @@ export default function KanbanColumn({
     onDrop(status);
   }
 
-  const showEndIndicator =
-    isDropTarget && dropIndicator?.beforeTaskId == null;
+  const showEndIndicator = isDropTarget && dropIndicator?.beforeTaskId == null;
 
   return (
     <div
@@ -58,18 +72,37 @@ export default function KanbanColumn({
       onDragOver={handleDragOver}
       onDrop={handleDrop}
     >
-      <div className="flex items-center justify-between px-1 pb-1">
-        <span className="font-bold text-sm text-gray-700">{label}</span>
-        <span className="bg-[#c2c7d0] text-xs font-bold px-2 py-0.5 rounded-full min-w-[22px] text-center text-gray-600">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-1 pb-1">
+        <span className="font-bold text-sm text-gray-700 shrink-0">{label}</span>
+        <span className="bg-[#c2c7d0] text-xs font-bold px-2 py-0.5 rounded-full min-w-[22px] text-center text-gray-600 shrink-0">
           {tasks.length}
         </span>
+        <div className="flex items-center gap-1 ml-auto">
+          {SORT_BUTTONS.map(({ key, label: btnLabel }) => {
+            const isActive = sortState.key === key;
+            const arrow = isActive ? (sortState.asc ? "↑" : "↓") : "";
+            return (
+              <button
+                key={key}
+                onClick={() => onSort(key)}
+                className={`text-xs px-1.5 py-0.5 rounded transition-colors whitespace-nowrap ${
+                  isActive
+                    ? "bg-blue-500 text-white font-semibold"
+                    : "bg-[#c2c7d0] text-gray-600 hover:bg-[#b0b5bf]"
+                }`}
+              >
+                {btnLabel}{arrow}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
+      {/* Task list */}
       <div className="flex flex-col">
         {tasks.map((task) => {
-          const showAbove =
-            isDropTarget && dropIndicator?.beforeTaskId === task.id;
-
+          const showAbove = isDropTarget && dropIndicator?.beforeTaskId === task.id;
           return (
             <div key={task.id}>
               {showAbove && <DropLine />}
@@ -103,7 +136,5 @@ export default function KanbanColumn({
 }
 
 function DropLine() {
-  return (
-    <div className="h-0.5 bg-blue-400 rounded-full mx-1 mb-2 shadow-sm" />
-  );
+  return <div className="h-0.5 bg-blue-400 rounded-full mx-1 mb-2 shadow-sm" />;
 }


### PR DESCRIPTION
## 概要
各カラムのヘッダーに「優先度」「期限」の並び替えボタンを追加した。ボタン押下時にそのカラムのタスクが並び替えられ、`POST /api/tasks/reorder` でバックエンドに永続化される。

## 変更内容

### KanbanBoard.tsx
- カラムごとのソート状態（key・昇順/降順）を `sortStates` で管理
- `sortColumnTasks` 関数でソートロジックを実装（優先度: high→medium→low→なし、期限: 昇順・期限なしは末尾）
- `handleSort` でソート実行 → 楽観的UI更新 → reorderTasks API呼び出し
- ドラッグ&ドロップ後はそのカラムのソート状態をリセット

### KanbanColumn.tsx
- ヘッダーに「優先度」「期限」ボタンを追加
- アクティブなボタンは青くハイライト
- 同じボタン再押下で昇順↔降順トグル（矢印 ↑↓ で表示）

Closes #24