### PR TITLE
feat: タスクの削除機能を追加（物理削除・カードゴミ箱ボタン） (#26)

### DIFF
--- a/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
@@ -53,6 +53,12 @@ public class TaskController {
         return ResponseEntity.ok(taskService.updateTask(id, request));
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTask(@PathVariable Integer id) {
+        taskService.deleteTask(id);
+        return ResponseEntity.noContent().build();
+    }
+
     @PostMapping("/reorder")
     public ResponseEntity<Void> reorderTasks(@RequestBody List<TaskReorderItemDto> items) {
         taskService.reorderTasks(items);

--- a/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
@@ -14,4 +14,5 @@ public interface TaskService {
     TaskResponseDto createTask(TaskCreateRequestDto request);
     TaskResponseDto updateTask(Integer id, TaskUpdateRequestDto request);
     void reorderTasks(List<TaskReorderItemDto> items);
+    void deleteTask(Integer id);
 }

--- a/backend/src/main/java/com/example/taskmanagement/service/TaskServiceImpl.java
+++ b/backend/src/main/java/com/example/taskmanagement/service/TaskServiceImpl.java
@@ -81,6 +81,13 @@ public class TaskServiceImpl implements TaskService {
 
     @Override
     @Transactional
+    public void deleteTask(Integer id) {
+        if (!taskRepository.existsById(id)) throw new TaskNotFoundException(id);
+        taskRepository.deleteById(id);
+    }
+
+    @Override
+    @Transactional
     public void reorderTasks(List<TaskReorderItemDto> items) {
         List<Integer> ids = items.stream().map(TaskReorderItemDto::id).toList();
         Map<Integer, Task> taskMap = taskRepository.findAllById(ids).stream()

--- a/frontend/src/api/taskApi.ts
+++ b/frontend/src/api/taskApi.ts
@@ -36,6 +36,11 @@ export async function updateTask(id: number, request: TaskUpdateRequest): Promis
   return res.json();
 }
 
+export async function deleteTask(id: number): Promise<void> {
+  const res = await fetch(`${BASE_URL}/api/tasks/${id}`, { method: "DELETE" });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+}
+
 export async function reorderTasks(items: TaskReorderItem[]): Promise<void> {
   const res = await fetch(`${BASE_URL}/api/tasks/reorder`, {
     method: "POST",

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -204,6 +204,7 @@ export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) 
             onSort={(key) => handleSort(status, key)}
             onAddTask={status === "todo" ? onAddTask : undefined}
             onTaskClick={setSelectedTask}
+            onTaskDelete={handleDeleteTask}
             onDragStart={handleDragStart}
             onDragEnd={handleDragEnd}
             onDragOverColumn={handleDragOverColumn}

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -10,9 +10,35 @@ const COLUMNS: { status: TaskStatus; label: string }[] = [
   { status: "done", label: "完了" },
 ];
 
+export type SortKey = "priority" | "dueDate";
+
+interface SortState {
+  key: SortKey | null;
+  asc: boolean;
+}
+
 interface DropIndicator {
   beforeTaskId: number | null;
   status: TaskStatus;
+}
+
+const PRIORITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 };
+
+function sortColumnTasks(tasks: Task[], sort: SortState): Task[] {
+  if (!sort.key) return tasks;
+  return [...tasks].sort((a, b) => {
+    if (sort.key === "priority") {
+      const aVal = a.priority != null ? (PRIORITY_ORDER[a.priority] ?? 3) : 3;
+      const bVal = b.priority != null ? (PRIORITY_ORDER[b.priority] ?? 3) : 3;
+      return sort.asc ? aVal - bVal : bVal - aVal;
+    } else {
+      if (!a.dueDate && !b.dueDate) return 0;
+      if (!a.dueDate) return sort.asc ? 1 : -1;
+      if (!b.dueDate) return sort.asc ? -1 : 1;
+      const cmp = a.dueDate.localeCompare(b.dueDate);
+      return sort.asc ? cmp : -cmp;
+    }
+  });
 }
 
 interface Props {
@@ -25,16 +51,48 @@ export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) 
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [draggingId, setDraggingId] = useState<number | null>(null);
   const [dropIndicator, setDropIndicator] = useState<DropIndicator | null>(null);
+  const [sortStates, setSortStates] = useState<Record<TaskStatus, SortState>>({
+    todo: { key: null, asc: true },
+    in_progress: { key: null, asc: true },
+    done: { key: null, asc: true },
+  });
   const dragIdRef = useRef<number | null>(null);
 
   const grouped = Object.fromEntries(
-    COLUMNS.map(({ status }) => [
-      status,
-      [...tasks.filter((t) => t.status === status)].sort(
+    COLUMNS.map(({ status }) => {
+      const colTasks = [...tasks.filter((t) => t.status === status)].sort(
         (a, b) => a.orderIndex - b.orderIndex
-      ),
-    ])
+      );
+      return [status, sortColumnTasks(colTasks, sortStates[status])];
+    })
   ) as Record<TaskStatus, Task[]>;
+
+  function handleSort(status: TaskStatus, key: SortKey) {
+    const current = sortStates[status];
+    const asc = current.key === key ? !current.asc : true;
+    const newSort: SortState = { key, asc };
+
+    setSortStates((prev) => ({ ...prev, [status]: newSort }));
+
+    const colTasks = [...tasks.filter((t) => t.status === status)].sort(
+      (a, b) => a.orderIndex - b.orderIndex
+    );
+    const sorted = sortColumnTasks(colTasks, newSort);
+    const reorderItems: TaskReorderItem[] = sorted.map((t, i) => ({
+      id: t.id,
+      orderIndex: i,
+      status: t.status,
+    }));
+
+    const updatedMap = new Map(reorderItems.map((r) => [r.id, r]));
+    const nextTasks = tasks.map((t) => {
+      const updated = updatedMap.get(t.id);
+      return updated ? { ...t, orderIndex: updated.orderIndex } : t;
+    });
+    onTasksChange(nextTasks);
+
+    reorderTasks(reorderItems).catch(() => onTasksChange(tasks));
+  }
 
   function handleDragStart(taskId: number) {
     dragIdRef.current = taskId;
@@ -81,13 +139,10 @@ export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) 
     targetColTasks.splice(insertIdx, 0, { ...dragged, status: targetStatus });
 
     const reorderItems: TaskReorderItem[] = [];
-
-    // Recalculate target column orderIndex
     targetColTasks.forEach((t, i) => {
       reorderItems.push({ id: t.id, orderIndex: i, status: targetStatus });
     });
 
-    // Recalculate source column if different
     if (dragged.status !== targetStatus) {
       grouped[dragged.status]
         .filter((t) => t.id !== id)
@@ -96,7 +151,6 @@ export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) 
         });
     }
 
-    // Apply optimistic update
     const updatedMap = new Map(reorderItems.map((r) => [r.id, r]));
     const nextTasks = tasks.map((t) => {
       const updated = updatedMap.get(t.id);
@@ -105,14 +159,22 @@ export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) 
     });
     onTasksChange(nextTasks);
 
+    // ドラッグ後はそのカラムのソートをリセット
+    if (dragged.status !== targetStatus) {
+      setSortStates((prev) => ({
+        ...prev,
+        [targetStatus]: { key: null, asc: true },
+        [dragged.status]: { key: null, asc: true },
+      }));
+    } else {
+      setSortStates((prev) => ({ ...prev, [targetStatus]: { key: null, asc: true } }));
+    }
+
     setDraggingId(null);
     setDropIndicator(null);
     dragIdRef.current = null;
 
-    reorderTasks(reorderItems).catch(() => {
-      // Revert on failure
-      onTasksChange(tasks);
-    });
+    reorderTasks(reorderItems).catch(() => onTasksChange(tasks));
   }
 
   async function handleSaveTask(id: number, request: TaskUpdateRequest) {
@@ -132,6 +194,8 @@ export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) 
             tasks={grouped[status]}
             draggingId={draggingId}
             dropIndicator={dropIndicator}
+            sortState={sortStates[status]}
+            onSort={(key) => handleSort(status, key)}
             onAddTask={status === "todo" ? onAddTask : undefined}
             onTaskClick={setSelectedTask}
             onDragStart={handleDragStart}

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import type { Task, TaskReorderItem, TaskStatus, TaskUpdateRequest } from "../types/task";
-import { reorderTasks, updateTask } from "../api/taskApi";
+import { deleteTask, reorderTasks, updateTask } from "../api/taskApi";
 import KanbanColumn from "./KanbanColumn";
 import TaskDetailModal from "./TaskDetailModal";
 
@@ -183,6 +183,12 @@ export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) 
     setSelectedTask(updated);
   }
 
+  async function handleDeleteTask(id: number) {
+    await deleteTask(id);
+    onTasksChange(tasks.filter((t) => t.id !== id));
+    setSelectedTask(null);
+  }
+
   return (
     <>
       <div className="flex gap-5 p-6 overflow-x-auto items-start flex-1 bg-[#f4f5f7]">
@@ -212,6 +218,7 @@ export default function KanbanBoard({ tasks, onTasksChange, onAddTask }: Props) 
           task={selectedTask}
           onClose={() => setSelectedTask(null)}
           onSave={handleSaveTask}
+          onDelete={handleDeleteTask}
         />
       )}
     </>

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -22,6 +22,7 @@ interface Props {
   onSort: (key: SortKey) => void;
   onAddTask?: () => void;
   onTaskClick: (task: Task) => void;
+  onTaskDelete: (taskId: number) => void;
   onDragStart: (taskId: number) => void;
   onDragEnd: () => void;
   onDragOverColumn: (status: TaskStatus) => void;
@@ -44,6 +45,7 @@ export default function KanbanColumn({
   onSort,
   onAddTask,
   onTaskClick,
+  onTaskDelete,
   onDragStart,
   onDragEnd,
   onDragOverColumn,
@@ -111,6 +113,7 @@ export default function KanbanColumn({
                   task={task}
                   isDragging={task.id === draggingId}
                   onClick={() => onTaskClick(task)}
+                  onDelete={() => onTaskDelete(task.id)}
                   onDragStart={() => onDragStart(task.id)}
                   onDragEnd={onDragEnd}
                   onDragOver={(above) => onDragOverCard(task.id, status, above)}

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -1,5 +1,11 @@
 import type { Task, TaskStatus } from "../types/task";
+import type { SortKey } from "./KanbanBoard";
 import TaskCard from "./TaskCard";
+
+interface SortState {
+  key: SortKey | null;
+  asc: boolean;
+}
 
 interface DropIndicator {
   beforeTaskId: number | null;
@@ -12,6 +18,8 @@ interface Props {
   tasks: Task[];
   draggingId: number | null;
   dropIndicator: DropIndicator | null;
+  sortState: SortState;
+  onSort: (key: SortKey) => void;
   onAddTask?: () => void;
   onTaskClick: (task: Task) => void;
   onDragStart: (taskId: number) => void;
@@ -21,12 +29,19 @@ interface Props {
   onDrop: (status: TaskStatus) => void;
 }
 
+const SORT_BUTTONS: { key: SortKey; label: string }[] = [
+  { key: "priority", label: "優先度" },
+  { key: "dueDate", label: "期限" },
+];
+
 export default function KanbanColumn({
   label,
   status,
   tasks,
   draggingId,
   dropIndicator,
+  sortState,
+  onSort,
   onAddTask,
   onTaskClick,
   onDragStart,
@@ -47,8 +62,7 @@ export default function KanbanColumn({
     onDrop(status);
   }
 
-  const showEndIndicator =
-    isDropTarget && dropIndicator?.beforeTaskId == null;
+  const showEndIndicator = isDropTarget && dropIndicator?.beforeTaskId == null;
 
   return (
     <div
@@ -58,18 +72,37 @@ export default function KanbanColumn({
       onDragOver={handleDragOver}
       onDrop={handleDrop}
     >
-      <div className="flex items-center justify-between px-1 pb-1">
-        <span className="font-bold text-sm text-gray-700">{label}</span>
-        <span className="bg-[#c2c7d0] text-xs font-bold px-2 py-0.5 rounded-full min-w-[22px] text-center text-gray-600">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-1 pb-1">
+        <span className="font-bold text-sm text-gray-700 shrink-0">{label}</span>
+        <span className="bg-[#c2c7d0] text-xs font-bold px-2 py-0.5 rounded-full min-w-[22px] text-center text-gray-600 shrink-0">
           {tasks.length}
         </span>
+        <div className="flex items-center gap-1 ml-auto">
+          {SORT_BUTTONS.map(({ key, label: btnLabel }) => {
+            const isActive = sortState.key === key;
+            const arrow = isActive ? (sortState.asc ? "↑" : "↓") : "";
+            return (
+              <button
+                key={key}
+                onClick={() => onSort(key)}
+                className={`text-xs px-1.5 py-0.5 rounded transition-colors whitespace-nowrap ${
+                  isActive
+                    ? "bg-blue-500 text-white font-semibold"
+                    : "bg-[#c2c7d0] text-gray-600 hover:bg-[#b0b5bf]"
+                }`}
+              >
+                {btnLabel}{arrow}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
+      {/* Task list */}
       <div className="flex flex-col">
         {tasks.map((task) => {
-          const showAbove =
-            isDropTarget && dropIndicator?.beforeTaskId === task.id;
-
+          const showAbove = isDropTarget && dropIndicator?.beforeTaskId === task.id;
           return (
             <div key={task.id}>
               {showAbove && <DropLine />}
@@ -103,7 +136,5 @@ export default function KanbanColumn({
 }
 
 function DropLine() {
-  return (
-    <div className="h-0.5 bg-blue-400 rounded-full mx-1 mb-2 shadow-sm" />
-  );
+  return <div className="h-0.5 bg-blue-400 rounded-full mx-1 mb-2 shadow-sm" />;
 }

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -15,6 +15,7 @@ interface Props {
   task: Task;
   isDragging: boolean;
   onClick: () => void;
+  onDelete: () => void;
   onDragStart: () => void;
   onDragEnd: () => void;
   onDragOver: (above: boolean) => void;
@@ -24,6 +25,7 @@ export default function TaskCard({
   task,
   isDragging,
   onClick,
+  onDelete,
   onDragStart,
   onDragEnd,
   onDragOver,
@@ -49,11 +51,20 @@ export default function TaskCard({
       }}
       onDragEnd={onDragEnd}
       onDragOver={handleDragOver}
-      className={`bg-white rounded-md shadow-sm p-3 cursor-pointer select-none transition-opacity hover:shadow-md ${
+      className={`group relative bg-white rounded-md shadow-sm p-3 cursor-pointer select-none transition-opacity hover:shadow-md ${
         isDragging ? "opacity-40" : "opacity-100"
       }`}
     >
-      <p className="text-sm font-medium text-gray-800 leading-snug">{task.title}</p>
+      <button
+        onClick={(e) => { e.stopPropagation(); onDelete(); }}
+        className="absolute top-1.5 right-1.5 p-1 rounded text-gray-300 hover:text-red-500 hover:bg-red-50 opacity-0 group-hover:opacity-100 transition-all"
+        tabIndex={-1}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+        </svg>
+      </button>
+      <p className="text-sm font-medium text-gray-800 leading-snug pr-5">{task.title}</p>
       {hasMeta && (
         <div className="flex items-center gap-2 mt-2">
           {priority && (

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -29,7 +29,6 @@ export default function TaskDetailModal({ task, onClose, onSave, onDelete }: Pro
   const [dueDate, setDueDate] = useState(task.dueDate ?? "");
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const titleRef = useRef<HTMLInputElement>(null);
 
@@ -73,18 +72,11 @@ export default function TaskDetailModal({ task, onClose, onSave, onDelete }: Pro
     } catch {
       setError("削除に失敗しました");
       setDeleting(false);
-      setConfirmDelete(false);
     }
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === "Escape") {
-      if (confirmDelete) {
-        setConfirmDelete(false);
-      } else {
-        onClose();
-      }
-    }
+    if (e.key === "Escape") onClose();
   }
 
   return (
@@ -200,34 +192,13 @@ export default function TaskDetailModal({ task, onClose, onSave, onDelete }: Pro
         {/* Footer */}
         <div className="flex items-center justify-between px-6 py-4 border-t border-gray-200">
           {/* Delete button (left side) */}
-          <div className="flex items-center gap-2">
-            {confirmDelete ? (
-              <>
-                <span className="text-sm text-red-600 font-medium">本当に削除しますか？</span>
-                <button
-                  onClick={handleDelete}
-                  disabled={deleting}
-                  className="px-3 py-1.5 text-sm font-semibold bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors"
-                >
-                  {deleting ? "削除中..." : "はい"}
-                </button>
-                <button
-                  onClick={() => setConfirmDelete(false)}
-                  disabled={deleting}
-                  className="px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
-                >
-                  いいえ
-                </button>
-              </>
-            ) : (
-              <button
-                onClick={() => setConfirmDelete(true)}
-                className="px-3 py-1.5 text-sm text-red-600 border border-red-300 rounded-lg hover:bg-red-50 transition-colors"
-              >
-                削除
-              </button>
-            )}
-          </div>
+          <button
+            onClick={handleDelete}
+            disabled={deleting}
+            className="px-3 py-1.5 text-sm text-red-600 border border-red-300 rounded-lg hover:bg-red-50 disabled:opacity-50 transition-colors"
+          >
+            {deleting ? "削除中..." : "削除"}
+          </button>
 
           {/* Save/Cancel buttons (right side) */}
           <div className="flex gap-2">

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -18,15 +18,18 @@ interface Props {
   task: Task;
   onClose: () => void;
   onSave: (id: number, request: TaskUpdateRequest) => Promise<void>;
+  onDelete: (id: number) => Promise<void>;
 }
 
-export default function TaskDetailModal({ task, onClose, onSave }: Props) {
+export default function TaskDetailModal({ task, onClose, onSave, onDelete }: Props) {
   const [title, setTitle] = useState(task.title);
   const [description, setDescription] = useState(task.description ?? "");
   const [status, setStatus] = useState<TaskStatus>(task.status);
   const [priority, setPriority] = useState<TaskPriority | "">(task.priority ?? "");
   const [dueDate, setDueDate] = useState(task.dueDate ?? "");
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const titleRef = useRef<HTMLInputElement>(null);
 
@@ -61,8 +64,27 @@ export default function TaskDetailModal({ task, onClose, onSave }: Props) {
     }
   }
 
+  async function handleDelete() {
+    setDeleting(true);
+    setError(null);
+    try {
+      await onDelete(task.id);
+      onClose();
+    } catch {
+      setError("削除に失敗しました");
+      setDeleting(false);
+      setConfirmDelete(false);
+    }
+  }
+
   function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === "Escape") onClose();
+    if (e.key === "Escape") {
+      if (confirmDelete) {
+        setConfirmDelete(false);
+      } else {
+        onClose();
+      }
+    }
   }
 
   return (
@@ -176,20 +198,53 @@ export default function TaskDetailModal({ task, onClose, onSave }: Props) {
         </div>
 
         {/* Footer */}
-        <div className="flex justify-end gap-2 px-6 py-4 border-t border-gray-200">
-          <button
-            onClick={onClose}
-            className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
-          >
-            キャンセル
-          </button>
-          <button
-            onClick={handleSave}
-            disabled={saving}
-            className="px-4 py-2 text-sm font-semibold bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
-          >
-            {saving ? "保存中..." : "保存"}
-          </button>
+        <div className="flex items-center justify-between px-6 py-4 border-t border-gray-200">
+          {/* Delete button (left side) */}
+          <div className="flex items-center gap-2">
+            {confirmDelete ? (
+              <>
+                <span className="text-sm text-red-600 font-medium">本当に削除しますか？</span>
+                <button
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className="px-3 py-1.5 text-sm font-semibold bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors"
+                >
+                  {deleting ? "削除中..." : "はい"}
+                </button>
+                <button
+                  onClick={() => setConfirmDelete(false)}
+                  disabled={deleting}
+                  className="px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+                >
+                  いいえ
+                </button>
+              </>
+            ) : (
+              <button
+                onClick={() => setConfirmDelete(true)}
+                className="px-3 py-1.5 text-sm text-red-600 border border-red-300 rounded-lg hover:bg-red-50 transition-colors"
+              >
+                削除
+              </button>
+            )}
+          </div>
+
+          {/* Save/Cancel buttons (right side) */}
+          <div className="flex gap-2">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            >
+              キャンセル
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="px-4 py-2 text-sm font-semibold bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {saving ? "保存中..." : "保存"}
+            </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概要

タスクの物理削除機能を実装しました。

Closes #26

## 変更内容

### バックエンド
- `TaskService` に `deleteTask(Integer id)` を追加
- `TaskServiceImpl` に物理削除ロジックを実装（存在しない場合は404）
- `DELETE /api/tasks/{id}` エンドポイントを追加（204 No Content）

### フロントエンド
- `taskApi.ts` に `deleteTask(id)` 関数を追加
- **タスクカード右上**にゴミ箱アイコンボタンを追加（ホバー時に表示、クリックで即削除）
- **タスク詳細モーダルのフッター左**に「削除」ボタンを追加（クリックで即削除）
- `KanbanBoard` → `KanbanColumn` → `TaskCard` へ削除コールバックを接続